### PR TITLE
customize datePicker locale and format, and more

### DIFF
--- a/public/rrdGraphCtrl.js
+++ b/public/rrdGraphCtrl.js
@@ -47,7 +47,9 @@ qxWeb.define('rrdGraphCtrl',{
             showTimeRanges: 'dropdown', // 'buttons'
             resetTimeOnDateChange: false,
             switchToCustomOnStartChange: true,
-            momentTz: null
+            momentTz: null,
+            datePickerLocale: 'en-US',
+            datePickerOptions: {},
         },
         rrdGraphCtrl: function(rrdGraphPngs,cfg){
             var ctrl = new rrdGraphCtrl(this);
@@ -113,10 +115,12 @@ qxWeb.define('rrdGraphCtrl',{
         },
         __addDatePicker: function(){
             var rrdGraphPngs = this.getProperty('rrdGraphPngs');
-            var start = qxWeb.create('<input  type="text"/>');
+            var start = qxWeb.create('<input type="text"/>');
             start.appendTo(this);
+            var datePickerLocale = this.getConfig('datePickerLocale');
+            var datePickerOptions = this.getConfig('datePickerOptions');
             var picker = start.datepicker().setConfig('format', function(date) {
-                return date.toDateString();
+                return date.toLocaleDateString(datePickerLocale, datePickerOptions);
             });
             var calendar = picker.getCalendar();
             calendar.setValue(new Date());

--- a/public/rrdGraphCtrl.js
+++ b/public/rrdGraphCtrl.js
@@ -40,6 +40,7 @@ qxWeb.define('rrdGraphCtrl',{
                 "4 Weeks":          { order: 13, len: 4*7*24*3600},
                 "12 Months":        { order: 14, len: 365*24*3600}
             },
+            timeRangesCustomLabel: 'Custom',
             initialTimeRange: 'Today',
             rangeMatchPrecision: 0.05,
             showTimeBox: true,
@@ -330,7 +331,7 @@ qxWeb.define('rrdGraphCtrl',{
                 }
 
             });
-            var custom = qxWeb.create('<option value="0">Custom</option>');
+            var custom = qxWeb.create('<option value="0">' + this.getConfig('timeRangesCustomLabel') + '</option>');
             rangeSelector.append(custom);
             var blockStart = false;
             var onRangeSelectorChange = function(e){


### PR DESCRIPTION
This commit adds option to customize the locale and format of the datePicker box. It works by using toLocaleDateString(locale, options) method.
The config fields for rrdGraphCtrl are: datePickerLocale (default: 'en-US'), and datePickerOptions (default: {}).
See source code and https://developer.mozilla.org/pl/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
